### PR TITLE
Pinned storefront to a light color scheme so OS dark mode no longer darkens the header

### DIFF
--- a/theme/layout/theme.liquid
+++ b/theme/layout/theme.liquid
@@ -5,6 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
+    {% comment %} Render the storefront in light regardless of the visitor's OS dark mode {% endcomment %}
+    <meta name="color-scheme" content="light">
+
     <link rel="canonical" href="{{ canonical_url }}">
 
     {% if settings.favicon != blank %}

--- a/theme/snippets/color-schemes.liquid
+++ b/theme/snippets/color-schemes.liquid
@@ -10,6 +10,15 @@
 -%}
 
 {% style %}
+    /* Pin the storefront to a light color scheme so a visitor's OS dark mode
+       does not repaint transparent/default areas (e.g. the header). The editor
+       host (Shopstory/apps-sdk) sets html[data-theme="dark"] from the OS, so we
+       override that selector too. */
+    html,
+    html[data-theme] {
+      color-scheme: light;
+    }
+
     :root {
       {% for scheme in settings.color_schemes %}
         {% for role in color_scheme_roles %}


### PR DESCRIPTION
### Problem
The storefront header (and other transparent areas) turn black when the visitor's computer is in OS dark mode. The theme has no dark-mode CSS of its own—the editor host sets `html[data-theme="dark"]` from the OS, and the browser then paints transparent/default areas with its dark canvas.

### Fix
Pin the storefront to a light color scheme so the visitor's OS preference can't repaint it:
- `theme/layout/theme.liquid` —> add `<meta name="color-scheme" content="light">`
- `theme/snippets/color-schemes.liquid` —> `html, html[data-theme] { color-scheme: light; }` (the `html[data-theme]` selector outranks the host's `html[data-theme="dark"]`) 
    
Only affects browser-default/transparent rendering; the theme's own color-scheme backgrounds are unchanged, so the light/dark theme styles still work.