### PR TITLE
fix: subscription typo in swell.json

### DIFF
--- a/swell.json
+++ b/swell.json
@@ -43,7 +43,7 @@
 	],
 	"purchase_options": [
 		"standard",
-		"susbcription"
+		"subscription"
 	],
 	"features": [
 		"multi_currency",


### PR DESCRIPTION
## Description

- Fixed typo in `subscription` in `swell.json`